### PR TITLE
chore: replace deprecated Node url.resolve with URL API

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": "^24.0.0"
+    "node": "^24.0.0",
+    "npm": "^11.0.0"
   },
   "scripts": {
     "start": "tsx scripts/dev-server.ts",

--- a/src/generator/feeds/create-atom-feed.ts
+++ b/src/generator/feeds/create-atom-feed.ts
@@ -1,5 +1,4 @@
 import path from 'node:path';
-import url from 'node:url';
 import { encodeHtml } from '../../utils/format';
 import { html, map } from '../../utils/render';
 import { DIR_DIST } from '../constants';
@@ -10,13 +9,13 @@ const FILE_NAME = 'atom.xml';
 
 export function createAtomFeed(): void {
   const { build, config } = getState();
-  const fileHref = url.resolve(build.baseUrl, FILE_NAME);
+  const fileHref = new URL(FILE_NAME, build.baseUrl).href;
 
   // It is important there is no whitespace before the XML tag.
   const contents = html`<?xml version="1.0" encoding="utf-8"?>
     <feed xmlns="http://www.w3.org/2005/Atom">
       <title>${config.title}</title>
-      <link href="${url.resolve(build.baseUrl, fileHref)}" rel="self" />
+      <link href="${new URL(fileHref, build.baseUrl).href}" rel="self" />
       <link href="${build.baseUrl}" />
       <updated>${build.buildDate.toISOString()}</updated>
       <id>${build.baseUrl}</id>

--- a/src/generator/feeds/create-rss-feed.ts
+++ b/src/generator/feeds/create-rss-feed.ts
@@ -1,5 +1,4 @@
 import path from 'node:path';
-import url from 'node:url';
 import { html, map } from '../../utils/render';
 import { DIR_DIST } from '../constants';
 import { getState } from '../state';
@@ -9,7 +8,7 @@ const FILE_NAME = 'rss.xml';
 
 export function createRssFeed(): void {
   const { build, config } = getState();
-  const fileHref = url.resolve(build.baseUrl, FILE_NAME);
+  const fileHref = new URL(FILE_NAME, build.baseUrl).href;
   const buildDate = build.buildDate.toUTCString();
 
   // It is important there is no whitespace before the XML tag.

--- a/src/generator/get-posts/get-metadata.ts
+++ b/src/generator/get-posts/get-metadata.ts
@@ -1,6 +1,5 @@
 import type { BuildConfig, ParsedFrontMatter, PostMetadata } from '@types';
 import path from 'node:path';
-import url from 'node:url';
 import { slugify } from '../../utils/format';
 import { DIR_SRC_STATIC, SOCIAL_FILE_NAME } from '../constants';
 
@@ -11,7 +10,7 @@ export function getMetadata(
   config: BuildConfig,
 ): PostMetadata {
   const relativePath = path.dirname(path.relative(DIR_SRC_STATIC, file)) + '/';
-  const _url = url.resolve(config.baseUrl, path.normalize(relativePath));
+  const url = new URL(relativePath, config.baseUrl).href;
   const description = fm.description || content.split('\n').filter(Boolean)[0];
 
   // Some properties could be added by spreading `frontMatter`. But now there is
@@ -25,8 +24,8 @@ export function getMetadata(
     updated: fm.updated,
     tags: fm.tags?.map((tag) => slugify(tag)),
     timeToRead: calculateTimeToRead(content),
-    url: _url,
-    socialUrl: url.resolve(_url, SOCIAL_FILE_NAME),
+    url,
+    socialUrl: new URL(SOCIAL_FILE_NAME, url).href,
   };
 }
 

--- a/src/generator/utils.ts
+++ b/src/generator/utils.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import url from 'node:url';
 import { DIR_DIST, DIR_SRC_LAYOUTS } from './constants';
 import { getState } from './state';
 
@@ -20,7 +19,7 @@ export function getLayoutPath(layout: string): string {
 export function resolveUrl(file: string): string {
   const relativePath = path.relative(DIR_DIST, file);
   const relativeUrl = path.normalize(path.dirname(relativePath) + '/');
-  return url.resolve(getState().build.baseUrl, relativeUrl);
+  return new URL(relativeUrl, getState().build.baseUrl).href;
 }
 
 /**

--- a/src/includes/layouts/base.ts
+++ b/src/includes/layouts/base.ts
@@ -1,5 +1,4 @@
 import type { Layout, ImportedPageData, Post } from '@types';
-import url from 'node:url';
 import { SOCIAL_MIME_TYPE } from '../../generator/constants';
 import { getState } from '../../generator/state';
 import { html, when } from '../../utils/render';
@@ -30,7 +29,7 @@ function getPageMetadata(data: ImportedPageData): PageMetadata {
 
   const image = post
     ? post.meta.socialUrl
-    : url.resolve(build.baseUrl, '/assets/img/social-homepage.jpg');
+    : new URL('/assets/img/social-homepage.jpg', build.baseUrl).href;
 
   const imageAlt = post
     ? `Banner that introduces the blog post by its title: ${post.meta.title}`
@@ -151,13 +150,13 @@ const layout: Layout = {
             rel="alternate"
             type="application/atom+xml"
             title="Posts on ${metadata.title}"
-            href="${url.resolve(build.baseUrl, 'atom.xml')}"
+            href="${new URL('atom.xml', build.baseUrl).href}"
           />
           <link
             rel="alternate"
             type="application/rss+xml"
             title="Posts on ${metadata.title}"
-            href="${url.resolve(build.baseUrl, 'rss.xml')}"
+            href="${new URL('rss.xml', build.baseUrl).href}"
           />
           ${when(build.env === 'PROD', () => addAnalytics())}
         </head>


### PR DESCRIPTION
Node's `url.resolve()` is [deprecated](https://nodejs.org/api/url.html#urlresolvefrom-to).

```txt
(node:92779) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.
```

It was only used to properly join URL parts (handling e.g. double slashes), which is an easy replace with the URL API.