### PR TITLE
feat: use new syntax for range media queries

### DIFF
--- a/src/static/assets/css/styles.css
+++ b/src/static/assets/css/styles.css
@@ -174,7 +174,7 @@ h3 {
     margin-right: 1.6rem;
     font-size: 2.4rem;
 
-    @media (min-width: 480px) {
+    @media (width >= 480px) {
       margin-right: 2.8rem;
     }
   }
@@ -188,7 +188,7 @@ h3 {
     padding: 0.6rem 1rem;
     border-radius: 0.4rem;
 
-    @media (min-width: 480px) {
+    @media (width >= 480px) {
       margin-right: 1.2rem;
       padding: 0.8rem 1.4rem;
     }
@@ -324,7 +324,7 @@ h3 {
     background-color: var(--color-shade-7);
     border-radius: 0.4rem;
 
-    @media (min-width: 480px) {
+    @media (width >= 480px) {
       margin-inline: 0;
       padding-inline: 3.2rem;
     }
@@ -342,7 +342,7 @@ h3 {
     white-space: pre;
     overflow: auto;
 
-    @media (min-width: 480px) {
+    @media (width >= 480px) {
       margin-inline: 0;
       padding-inline: 2.4rem;
     }
@@ -452,7 +452,7 @@ h3 {
     margin: 2.4rem 0 0;
     font-size: 2.6rem;
 
-    @media (min-width: 480px) {
+    @media (width >= 480px) {
       span {
         display: block;
       }
@@ -491,7 +491,7 @@ h3 {
       width: 10rem;
       height: 10rem;
 
-      @media (min-width: 480px) {
+      @media (width >= 480px) {
         width: 12rem;
         height: 12rem;
       }
@@ -501,7 +501,7 @@ h3 {
       flex: 1 1 auto;
       padding-left: 2rem;
 
-      @media (min-width: 480px) {
+      @media (width >= 480px) {
         padding-left: 4rem;
       }
     }

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -5,7 +5,6 @@
 const config = {
   extends: 'stylelint-config-standard',
   rules: {
-    'media-feature-range-notation': null, // Lacks desired browser support
     'no-descending-specificity': null,
   },
 };


### PR DESCRIPTION
The range syntax for media queries is baseline for a while now.